### PR TITLE
Don't update devices when adding them

### DIFF
--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -167,7 +167,7 @@ async def async_setup_platform(
                 IntesisAC(ih_device_id, device, controller)
                 for ih_device_id, device in ih_devices.items()
             ],
-            update_before_add=True,
+            update_before_add=False,
         )
     else:
         _LOGGER.error(


### PR DESCRIPTION
 I debugged a lot and saw that somewhere in the initialization the first device is created, updated, then added to HA and then connected to the API. The second device gets updated before the first one is connected to the API and somehow, the device list of the controller is empty then, resulting in the above error.

See https://github.com/jnimmo/hass-intesishome/issues/7