### PR TITLE
Forwarding setup to config entry platforms

### DIFF
--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -16,9 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, "climate")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
 
     return True
 


### PR DESCRIPTION
See
https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ and 
 https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/